### PR TITLE
ci(github): set permissions in test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: test
 on: [push, pull_request]
 
+permissions:
+  contents: write
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## What is the motivation for this pull request?

ci(github): set permissions in test.yml

```
 ! [remote rejected] test/ubuntu-latest-17192824683 -> test/ubuntu-latest-17192824683 (refusing to allow a GitHub App to create or update workflow `.github/workflows/commitlint.yml` without `workflows` permission)
error: failed to push some refs to 'https://github.com/remarkablemark/sync-branch'
```

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation